### PR TITLE
Bump Scala 3 to RC1

### DIFF
--- a/src/main/g8/build.sbt
+++ b/src/main/g8/build.sbt
@@ -1,4 +1,4 @@
-val scala3Version = "3.0.0-M3"
+val scala3Version = "3.0.0-RC1"
 
 lazy val lib = project
   .in(file("lib"))


### PR DESCRIPTION
This currently fails due to a reworked API of TASTy Reflect:

```scala
[error] -- [E006] Not Found Error: /Users/kmetiuk/Projects/scala3/tools/dotty-release-scripts/ecosystem_projects/foo/inspector/src/main/scala/inspector/Inspector.scala:11:24
[error] 11 |    val inspector = new TastyInspector {
[error]    |                        ^^^^^^^^^^^^^^
[error]    |                        Not found: type TastyInspector
[error] -- [E008] Not Found Error: /Users/kmetiuk/Projects/scala3/tools/dotty-release-scripts/ecosystem_projects/foo/inspector/src/main/scala/inspector/Inspector.scala:18:14
[error] 18 |    inspector.inspectTastyFiles(List(tastyFile))
[error]    |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^
[error]    |    value inspectTastyFiles is not a member of Object
```

`inspector` project relies on the `processCompilationUnit` method which was removed. Using `TastyInspector` object directly without that method results in tests failures (read `null` instead of some meaningful content). @nicolasstucki any idea how to fix this?